### PR TITLE
Add ability to zoom out and ability to scale y-axis

### DIFF
--- a/lang/cn.json
+++ b/lang/cn.json
@@ -2,6 +2,7 @@
 	"_lang": "简体中文",
 	"general": "常规",
 	"zoom": "缩放",
+	"y_scale": "Y-Scale",
 	"offset": "偏移",
 	"position": "位置",
 	"bpm": "BPM",

--- a/lang/en.json
+++ b/lang/en.json
@@ -2,6 +2,7 @@
 	"_lang": "English",
 	"general": "General",
 	"zoom": "Zoom",
+	"y_scale": "Y-Scale",
 	"offset": "Offset",
 	"position": "Position",
 	"bpm": "BPM",

--- a/lang/es.json
+++ b/lang/es.json
@@ -2,6 +2,7 @@
 	"_lang": "Español",
 	"general": "General",
 	"zoom": "Zoom",
+	"y_scale": "Y-Scale",
 	"offset": "Offset",
 	"position": "Posición",
 	"bpm": "PPM",

--- a/lang/jp.json
+++ b/lang/jp.json
@@ -2,6 +2,7 @@
 	"_lang": "日本語",
 	"general": "基本設定",
 	"zoom": "ズーム",
+	"y_scale": "Y軸スケール",
 	"offset": "ずらし",
 	"position": "位置",
 	"bpm": "BPM",

--- a/lang/kr.json
+++ b/lang/kr.json
@@ -2,6 +2,7 @@
 	"_lang": "한국어",
 	"general": "일반",
 	"zoom": "확대",
+	"y_scale": "Y-Scale",
 	"offset": "오프셋",
 	"position": "위치",
 	"bpm": "BPM",

--- a/sayaslicer/sayaslicer.cpp
+++ b/sayaslicer/sayaslicer.cpp
@@ -157,13 +157,13 @@ void ShowSettingsPanel(SoundBuffer& buffer, SlicerSettings& settings) {
         static float yScaleLog = 0;
 
         ImGui::SeparatorText("general"_t.c_str());
-        ImGui::SliderFloat("x-zoom"_t.c_str(), &zoom, -60, 60);
+        ImGui::SliderFloat("zoom"_t.c_str(), &zoom, -60, 60);
         AddScalarScroll(ImGuiDataType_Float, &zoom, -60, 60, 1);
         if (ImGui::IsItemHovered() && ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
             zoom = 0;
         }
         settings.maxDisplayRange = minZoom * pow(2, -zoom/12);
-        ImGui::SliderFloat("y-scale"_t.c_str(), &yScaleLog, -30, 60);
+        ImGui::SliderFloat("y_scale"_t.c_str(), &yScaleLog, -30, 60);
         AddScalarScroll(ImGuiDataType_Float, &yScaleLog, -30, 60, 1);
         if (ImGui::IsItemHovered() && ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
             yScaleLog = 0;
@@ -562,7 +562,7 @@ int main() {
 #endif
 
     float dpiScale = GetDpiScale();
-    GLFWwindow* window = glfwCreateWindow(870 * dpiScale, 477 * dpiScale, "sayaslicer", nullptr, nullptr);
+    GLFWwindow* window = glfwCreateWindow(870 * dpiScale, 480 * dpiScale, "sayaslicer", nullptr, nullptr);
     if (window == nullptr)
         return 1;
     glfwMakeContextCurrent(window);

--- a/sayaslicer/sayaslicer.cpp
+++ b/sayaslicer/sayaslicer.cpp
@@ -154,11 +154,21 @@ void ShowSettingsPanel(SoundBuffer& buffer, SlicerSettings& settings) {
         double minPos = 0;
         double maxPos = buffer.getSampleCount();
         static float zoom = 0;
+        static float yScaleLog = 0;
 
         ImGui::SeparatorText("general"_t.c_str());
-        ImGui::SliderFloat("zoom"_t.c_str(), &zoom, 0, minZoom - waveformReso * 2.0);
-        AddScalarScroll(ImGuiDataType_Float, &zoom, 0, minZoom - waveformReso * 2.0, 200);
-        settings.maxDisplayRange = minZoom - zoom;
+        ImGui::SliderFloat("x-zoom"_t.c_str(), &zoom, -120, 60);
+        AddScalarScroll(ImGuiDataType_Float, &zoom, -120, 60, 1);
+        if (ImGui::IsItemHovered() && ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
+            zoom = 0;
+        }
+        settings.maxDisplayRange = minZoom * pow(2, -zoom/12);
+        ImGui::SliderFloat("y-scale"_t.c_str(), &yScaleLog, -30, 60);
+        AddScalarScroll(ImGuiDataType_Float, &yScaleLog, -30, 60, 1);
+        if (ImGui::IsItemHovered() && ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
+            yScaleLog = 0;
+        }
+        settings.yScale = pow(2, yScaleLog/12);
         ImGui::DragInt("offset"_t.c_str(), &settings.offset, 1, 0, 1000);
         AddScalarScroll(ImGuiDataType_S32, &settings.offset, 0, 1000, 10);
         ImGui::DragScalar("position"_t.c_str(), ImGuiDataType_Double, &settings.cursorPos, 1, &minPos, &maxPos);

--- a/sayaslicer/sayaslicer.cpp
+++ b/sayaslicer/sayaslicer.cpp
@@ -157,8 +157,8 @@ void ShowSettingsPanel(SoundBuffer& buffer, SlicerSettings& settings) {
         static float yScaleLog = 0;
 
         ImGui::SeparatorText("general"_t.c_str());
-        ImGui::SliderFloat("x-zoom"_t.c_str(), &zoom, -120, 60);
-        AddScalarScroll(ImGuiDataType_Float, &zoom, -120, 60, 1);
+        ImGui::SliderFloat("x-zoom"_t.c_str(), &zoom, -60, 60);
+        AddScalarScroll(ImGuiDataType_Float, &zoom, -60, 60, 1);
         if (ImGui::IsItemHovered() && ImGui::IsMouseClicked(ImGuiMouseButton_Right)) {
             zoom = 0;
         }

--- a/sayaslicer/settings.hpp
+++ b/sayaslicer/settings.hpp
@@ -28,6 +28,7 @@ public:
 	bool openMidiModalTemp = false;
 	UserPreferences prefs;
 	float maxDisplayRange = 1.0;
+	float yScale = 1.0;
 	bool openAboutModalTemp = false;
 	int keysoundOffsetEnd = 0;
 

--- a/sayaslicer/waveform.cpp
+++ b/sayaslicer/waveform.cpp
@@ -116,7 +116,7 @@ void DisplayWaveform(SoundBuffer& buffer, SlicerSettings& settings) {
         double plotStart = (settings.cursorPos - leftMargin) / waveformReso;
         double plotEnd = plotStart + maxDisplayRange;
         ImPlot::SetupAxisLinks(ImAxis_X1, &plotStart, &plotEnd);
-        ImPlot::SetupAxisLimits(ImAxis_Y1, -1.0f, 1.0f);
+        ImPlot::SetupAxisLimits(ImAxis_Y1, -1.0f/settings.yScale, 1.0f/settings.yScale, ImGuiCond_Always);
 
         ImPlot::SetupAxis(ImAxis_Y1, "", ImPlotAxisFlags_NoGridLines | ImPlotAxisFlags_NoTickLabels | ImPlotAxisFlags_Lock | ImPlotAxisFlags_NoTickMarks);
         ImPlot::SetupAxis(ImAxis_X1, "", ImPlotAxisFlags_Foreground | ImPlotAxisFlags_NoTickLabels);
@@ -186,8 +186,8 @@ void DisplayWaveform(SoundBuffer& buffer, SlicerSettings& settings) {
                 if (!tmp.empty())
                     wavBuf = tmp.data();
             }
-
-            ImPlot::PlotLine("Waveform", wavBuf, arrLen, 1.0, arrayOffset / (waveformReso), 0, settings.offset, stride * sizeof(float)); // Buffer stores samples as [channel1_i, channel2_i, channel1_i+1, etc.]
+            int downsample = (int)std::max(settings.maxDisplayRange/minZoom, 1.0); // for performance reasons when zoomed out
+            ImPlot::PlotLine("Waveform", wavBuf, arrLen / downsample, downsample, arrayOffset / (waveformReso), 0, settings.offset, downsample * stride * sizeof(float)); // Buffer stores samples as [channel1_i, channel2_i, channel1_i+1, etc.]
 
             // Display cursor
             double curDisplayPos = settings.cursorPos / waveformReso;


### PR DESCRIPTION
Currently you can only zoom in on the x-axis
Now the zoom scale is from -60 to 60, where -60 is 2^(60/12) = 32 times zoomed out, and +60 is 32 times zoomed in.
Useful to get a better idea of where you are in the song

Same for y-axis (useful if your keysounds are relatively soft and you want to inspect the waveform more closely)

Oh and also you can now right click the zoom sliders to reset to default zoom

Also added downsampling to the waveform drawing process when you are zoomed out by a significant amount. This improves performance a little while you are very zoomed out.