### PR TITLE
Add line that goes forward when you play a keysound and ability to set markers on that line.

### DIFF
--- a/sayaslicer/audio.cpp
+++ b/sayaslicer/audio.cpp
@@ -92,9 +92,11 @@ void PlayKeysound(SoundBuffer& buffer, SlicerSettings& settings, bool jumpToNext
             ApplyFadein(tmpBuf, settings.fadein, buffer.getSampleRate(), buffer.getChannelCount());
         if (settings.fadeout != 0)
             ApplyFadeout(tmpBuf, settings.fadeout, buffer.getSampleRate(), buffer.getChannelCount());
+        buffer.setStartPlayPos(keyStart);
         buffer.play(tmpBuf);
     }
     else {
+        buffer.setStartPlayPos(keyStart);
         buffer.play(keyStart, bufsize);
     }
 

--- a/sayaslicer/sayaslicer.cpp
+++ b/sayaslicer/sayaslicer.cpp
@@ -363,6 +363,28 @@ void ProcessShortcuts(ImGuiIO& io, SoundBuffer& buffer, SlicerSettings& settings
         size_t endPos = settings.samplesPerSnap * (int)(buffer.getSampleCount() / settings.samplesPerSnap);
         settings.cursorPos = endPos - settings.samplesPerSnap * (endPos > 0 && (size_t)(endPos - buffer.getSampleCount()) == 0);
     }
+    if (!io.WantTextInput && !io.WantCaptureKeyboard && !io.KeyCtrl && ImGui::IsKeyPressed(ImGuiKey_Q, false)) {
+        AddMarkerAtKeysoundPlayPosition(buffer, settings, false);
+    }
+    if (!io.WantTextInput && !io.WantCaptureKeyboard && !io.KeyCtrl && ImGui::IsKeyPressed(ImGuiKey_W, false)) {
+        AddMarkerAtKeysoundPlayPosition(buffer, settings, true);
+    }
+}
+
+void AddMarkerAtKeysoundPlayPosition(SoundBuffer& buffer, SlicerSettings& settings, bool jumpToMarker) {
+    if (!buffer.isPlaying()) return;
+    auto placePosition = buffer.getLastKnownPlayPos();
+    buffer.stop();
+    double e = settings.markers.find(placePosition);
+    if (e == -1.0) {
+        settings.markers.push_back(placePosition);
+    }
+    settings.updateHistory = true;
+
+    if (jumpToMarker) {
+        settings.cursorPos = placePosition;
+        PlayKeysound(buffer, settings, false);
+    }
 }
 
 void DisplayMarkersTable(SlicerSettings& settings) {

--- a/sayaslicer/sayaslicer.cpp
+++ b/sayaslicer/sayaslicer.cpp
@@ -371,22 +371,6 @@ void ProcessShortcuts(ImGuiIO& io, SoundBuffer& buffer, SlicerSettings& settings
     }
 }
 
-void AddMarkerAtKeysoundPlayPosition(SoundBuffer& buffer, SlicerSettings& settings, bool jumpToMarker) {
-    if (!buffer.isPlaying()) return;
-    auto placePosition = buffer.getLastKnownPlayPos();
-    buffer.stop();
-    double e = settings.markers.find(placePosition);
-    if (e == -1.0) {
-        settings.markers.push_back(placePosition);
-    }
-    settings.updateHistory = true;
-
-    if (jumpToMarker) {
-        settings.cursorPos = placePosition;
-        PlayKeysound(buffer, settings, false);
-    }
-}
-
 void DisplayMarkersTable(SlicerSettings& settings) {
     ImVec2 outer_size = ImVec2(0.0f, ImGui::GetTextLineHeightWithSpacing() * 8);
     if (ImGui::BeginTable("markerstable", 3, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_ScrollY, outer_size))

--- a/sayaslicer/sayaslicer.hpp
+++ b/sayaslicer/sayaslicer.hpp
@@ -51,3 +51,5 @@
 #endif
 
 const int mainSnaps[] = { 1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64, 96, 128, 192 };
+
+inline void AddMarkerAtKeysoundPlayPosition(SoundBuffer& buffer, SlicerSettings& settings, bool jumpToMarker);

--- a/sayaslicer/sayaslicer.hpp
+++ b/sayaslicer/sayaslicer.hpp
@@ -51,5 +51,3 @@
 #endif
 
 const int mainSnaps[] = { 1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64, 96, 128, 192 };
-
-inline void AddMarkerAtKeysoundPlayPosition(SoundBuffer& buffer, SlicerSettings& settings, bool jumpToMarker);

--- a/sayaslicer/sound_buffer.cpp
+++ b/sayaslicer/sound_buffer.cpp
@@ -149,6 +149,7 @@ bool SoundBuffer::writeFile(std::filesystem::path path, unsigned int sampleRate,
 void SoundBuffer::play(unsigned long long samplePos, unsigned long long length, const float* buffer) {
 	if (stream != NULL)
 		Pa_CloseStream(stream);
+	
 	struct callbackData* data = (struct callbackData*)calloc(1, sizeof(struct callbackData));
 	if (!data)
 		throw std::runtime_error("Cannot allocate PortAudio user data (this should not happen)");

--- a/sayaslicer/sound_buffer.cpp
+++ b/sayaslicer/sound_buffer.cpp
@@ -26,6 +26,7 @@ int callback(const void* input, void* output, unsigned long frameCount, const Pa
 		buffer = callbackData->buffer->data();
 
 	if (callbackData->currentPos >= callbackData->length) {
+		callbackData->sound->updatePlayProgress(callbackData->length);
 		return paComplete;
 	}
 
@@ -39,9 +40,11 @@ int callback(const void* input, void* output, unsigned long frameCount, const Pa
 	memcpy(out, &buffer[callbackData->samplePos + callbackData->currentPos], numSamplesToCopy * sizeof(float));
 
 	if (complete) {
+		callbackData->sound->updatePlayProgress(callbackData->length);
 		return paComplete;
 	}
 	callbackData->currentPos += numSamplesToCopy;
+	callbackData->sound->updatePlayProgress(callbackData->currentPos);
 	return paContinue;
 }
 
@@ -146,7 +149,6 @@ bool SoundBuffer::writeFile(std::filesystem::path path, unsigned int sampleRate,
 void SoundBuffer::play(unsigned long long samplePos, unsigned long long length, const float* buffer) {
 	if (stream != NULL)
 		Pa_CloseStream(stream);
-
 	struct callbackData* data = (struct callbackData*)calloc(1, sizeof(struct callbackData));
 	if (!data)
 		throw std::runtime_error("Cannot allocate PortAudio user data (this should not happen)");
@@ -180,9 +182,25 @@ void SoundBuffer::play(std::vector<float>& buffer) {
 }
 
 bool SoundBuffer::isPlaying() {
+	if (stream == NULL) return false;
 	return Pa_IsStreamActive(stream);
 }
 
 void SoundBuffer::stop() {
+	if (stream == NULL) return;
 	Pa_AbortStream(stream);
 }
+
+void SoundBuffer::setStartPlayPos(unsigned long long value) {
+	this->startPlayPos = value;
+	this->relativePlayPos = 0;
+}
+
+void SoundBuffer::updatePlayProgress(unsigned long long value) {
+	this->relativePlayPos = value;
+}
+
+unsigned long long SoundBuffer::getLastKnownPlayPos() {
+	return this->startPlayPos + this->relativePlayPos;
+}
+

--- a/sayaslicer/sound_buffer.hpp
+++ b/sayaslicer/sound_buffer.hpp
@@ -11,12 +11,12 @@ private:
 	unsigned int sampleRate = 0;
 	float duration = 0.0f;
 	PaStream* stream = NULL;
+	unsigned long long startPlayPos = 0;
+	unsigned long long relativePlayPos = 0;
 
 	void play(unsigned long long samplePos, unsigned long long length, const float* buffer);
 
 public:
-	unsigned long long startPlayPos = 0;
-	unsigned long long relativePlayPos = 0;
 
 	~SoundBuffer();
 

--- a/sayaslicer/sound_buffer.hpp
+++ b/sayaslicer/sound_buffer.hpp
@@ -15,6 +15,9 @@ private:
 	void play(unsigned long long samplePos, unsigned long long length, const float* buffer);
 
 public:
+	unsigned long long startPlayPos = 0;
+	unsigned long long relativePlayPos = 0;
+
 	~SoundBuffer();
 
 	float getDuration();
@@ -27,6 +30,9 @@ public:
 	void play(std::vector<float>& buffer);
 	bool isPlaying();
 	void stop();
+	void setStartPlayPos(unsigned long long value);
+	void updatePlayProgress(unsigned long long value);
+	unsigned long long getLastKnownPlayPos();
 
 	static bool writeFile(std::filesystem::path path, unsigned int sampleRate, unsigned int channelCount, float *buffer, size_t bufSize);
 };

--- a/sayaslicer/utils.cpp
+++ b/sayaslicer/utils.cpp
@@ -2,6 +2,9 @@
 #include <imgui_impl_glfw.h>
 
 #include "utils.hpp"
+#include "settings.hpp"
+#include "sound_buffer.hpp"
+#include "audio.hpp"
 
 std::string GetTempMarkerName(std::string filename, size_t idx) {
     std::string suffix = "_";
@@ -184,4 +187,20 @@ void SnapAllMarkers(SlicerSettings& settings, double maxLen) {
 
 float GetDpiScale() {
     return ImGui_ImplGlfw_GetContentScaleForMonitor(glfwGetPrimaryMonitor());
+}
+
+void AddMarkerAtKeysoundPlayPosition(SoundBuffer& buffer, SlicerSettings& settings, bool jumpToMarker) {
+    if (!buffer.isPlaying()) return;
+    auto placePosition = buffer.getLastKnownPlayPos();
+    buffer.stop();
+    double e = settings.markers.find(placePosition);
+    if (e == -1.0) {
+        settings.markers.push_back(placePosition);
+    }
+    settings.updateHistory = true;
+
+    if (jumpToMarker) {
+        settings.cursorPos = placePosition;
+        PlayKeysound(buffer, settings, false);
+    }
 }

--- a/sayaslicer/utils.hpp
+++ b/sayaslicer/utils.hpp
@@ -6,8 +6,9 @@
 #include <clip/clip.h>
 #include <sstream>
 #include <iconv.h>
-#include "settings.hpp"
 #include "base_convert.hpp"
+class SlicerSettings;
+class SoundBuffer;
 
 std::string GetTempMarkerName(std::string filename, size_t idx);
 void ExportKeysoundList(SlicerSettings settings, bool writeToFile);
@@ -16,3 +17,4 @@ long long LoadFileUnicode(std::string path, std::vector<char>& buf);
 void GetStartingKeysoundFromBMS(SlicerSettings& settings);
 void SnapAllMarkers(SlicerSettings& settings, double maxLen);
 float GetDpiScale();
+void AddMarkerAtKeysoundPlayPosition(SoundBuffer& buffer, SlicerSettings& settings, bool jumpToMarker);

--- a/sayaslicer/waveform.cpp
+++ b/sayaslicer/waveform.cpp
@@ -189,6 +189,11 @@ void DisplayWaveform(SoundBuffer& buffer, SlicerSettings& settings) {
 
             ImPlot::PlotLine("Waveform", wavBuf, arrLen, 1.0, arrayOffset / (waveformReso), 0, settings.offset, stride * sizeof(float)); // Buffer stores samples as [channel1_i, channel2_i, channel1_i+1, etc.]
 
+            if (buffer.isPlaying()) {
+                double tmp = buffer.getLastKnownPlayPos() / waveformReso;
+                ImPlot::DragLineX(555, &tmp, ImVec4(1, 1, 1, 0.25), 0.25, ImPlotDragToolFlags_NoInputs);
+            }
+
             // Display cursor
             double curDisplayPos = settings.cursorPos / waveformReso;
             ImPlot::DragLineX(555, &curDisplayPos, ImGui::GetStyleColorVec4(ImGuiCol_PlotLines), 0.5, ImPlotDragToolFlags_NoInputs);


### PR DESCRIPTION
I think it may sometimes be a little difficult to have an idea of where exactly you are in the waveform while the keysound is playing (to figure out where you really want to chop it), so I added a little line that goes forward as the keysound plays, that shows exactly where it is playing at in the waveform.

Also added two more hotkeys for this feature:
- Q: Place marker on the position of that moving line and stop playing the keysound.
- W: Place marker on the position of that moving line, jump to that marker, and continue playing the audio.

These marker positions are probably going to be pretty imprecise if you are placing them via Q or W but they can be fine-tuned later.